### PR TITLE
Prom Query was having the start time all the way back in the 1970's. …

### DIFF
--- a/server/Controllers/promMetrics.ts
+++ b/server/Controllers/promMetrics.ts
@@ -11,13 +11,13 @@ export const getSomething: RequestHandler = async (_, res, next) => {
     //current time
     let end = new Date();
     //range of query (mintues) :1min * 1000ms/s * 60s/min
-    const range = 10 * 60000;
-    let start = new Date(end.getMilliseconds() - range);
+    let start = new Date();
+    start.setMinutes(end.getMinutes()-10)
     //range query string to append to base prom fetch
     let queryString = `&start=${start.toISOString()}&end=${end.toISOString()}&step=${step}`;
     //fetch prometheus
     const data = await fetch(
-      `http://localhost:30122/api/v1/query_range?query=my_custom_counter${queryString}`
+      `http://localhost:31302/api/v1/query_range?query=my_custom_counter${queryString}`
     );
     const result = await data.json();
     //set response data object


### PR DESCRIPTION
recalculated the start time of the prometheus time series query to be 10 mins before current time. Was getting query starting from the 1970s.

